### PR TITLE
YCM fix for catkin build users

### DIFF
--- a/ycm_extra_conf.py
+++ b/ycm_extra_conf.py
@@ -26,7 +26,7 @@ def find_workspace_above(dirname):
     with open('/tmp/ycm.log', 'a') as logfile:
         logfile.write('Testing directory {} for workspace...'.format(dirname))
 
-        # .catkin_worspace is generated if you use `catkin_make`
+        # .catkin_workspace is generated if you use `catkin_make`
         if os.path.exists(os.path.join(dirname, '.catkin_workspace')):
             logfile.write('Succeeded\n')
             return dirname

--- a/ycm_extra_conf.py
+++ b/ycm_extra_conf.py
@@ -26,7 +26,12 @@ def find_workspace_above(dirname):
     with open('/tmp/ycm.log', 'a') as logfile:
         logfile.write('Testing directory {} for workspace...'.format(dirname))
 
+        # .catkin_worspace is generated if you use `catkin_make`
         if os.path.exists(os.path.join(dirname, '.catkin_workspace')):
+            logfile.write('Succeeded\n')
+            return dirname
+        # if using `catkin build`
+        if os.path.exists(os.path.join(dirname, '.catkin_tools')):
             logfile.write('Succeeded\n')
             return dirname
         logfile.write('Failed\n')


### PR DESCRIPTION
YCM would not recognize work spaces using `catkin build` AKA using catkin tools for workspace management. This adds a second check to fix that, which checks that the `.catkin_tools` directory exists, which is generated by `catkin build`